### PR TITLE
Add CLI interface and license

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "clap"
+version = "2.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,7 +396,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe9db393664b0e6c6230a14115e7e798f80b70f54038dc21165db24c6b7f28fc"
 dependencies = [
- "proc-macro-error",
+ "proc-macro-error 0.4.12",
  "proc-macro2",
  "quote",
  "syn",
@@ -621,6 +636,15 @@ dependencies = [
  "slab",
  "string",
  "tokio-io",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1159,7 +1183,20 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
 dependencies = [
- "proc-macro-error-attr",
+ "proc-macro-error-attr 0.4.12",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
+dependencies = [
+ "proc-macro-error-attr 1.0.2",
  "proc-macro2",
  "quote",
  "syn",
@@ -1171,6 +1208,19 @@ name = "proc-macro-error-attr"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "syn-mid",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1309,6 +1359,7 @@ dependencies = [
  "pretty_env_logger",
  "serde",
  "serde_derive",
+ "structopt",
  "surf",
  "tide",
 ]
@@ -1471,6 +1522,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "structopt"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff6da2e8d107dfd7b74df5ef4d205c6aebee0706c647f6bc6a2d5789905c00fb"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a489c87c08fbaf12e386665109dd13470dcc9c4583ea3e10dd2b4523e5ebd9ac"
+dependencies = [
+ "heck",
+ "proc-macro-error 1.0.2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "surf"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1521,6 +1602,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1728,6 +1818,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1760,6 +1862,12 @@ name = "vcpkg"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
+
+[[package]]
+name = "vec_map"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ pretty_env_logger = "0.4.0"
 async-trait = "0.1.26"
 horrorshow = "0.8.3"
 mime = "0.3.16"
+structopt = "0.3.12"
 
 [dev-dependencies]
 mockito = "0.23.3"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ rs-readme
 in any folder to start the server there.
 
 ### Todos (maybe)
-- [ ] Add a real CLI
+- [x] Add a real CLI
 - [ ] Better error messages
 - [ ] Auto reloading on file save
 - [ ] Testing on multiple platforms

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,18 @@
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+#[structopt(name = "rs-readme", about = "A simple web server for previewing .md files")]
+pub struct Args {
+    /// The host to serve the readme files on
+    #[structopt(short, long, default_value = "127.0.0.1")]
+    pub host: String,
+
+    /// The port to serve the readme files on
+    #[structopt(short, long, default_value = "4000")]
+    pub port: usize,
+
+    /// The folder to use as the root when serving files
+    #[structopt(short, long, default_value = ".")]
+    pub folder: PathBuf,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,11 +3,13 @@ extern crate horrorshow;
 #[macro_use]
 extern crate serde_derive;
 
+mod cli;
 mod content_finder;
 mod markdown_converter;
 mod static_files;
 mod web_server;
 
+pub use cli::Args;
 pub use content_finder::{ContentError, ContentFinder, FileFinder};
 pub use markdown_converter::{Converter, MarkdownConverter, MarkdownError};
 pub use web_server::{build_app, State};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,27 +1,28 @@
-use std::env;
-use std::path::PathBuf;
+use structopt::StructOpt;
 
-use rs_readme::Converter;
-use rs_readme::FileFinder;
-use rs_readme::{build_app, State};
+use rs_readme::{build_app, State, Converter, FileFinder, Args};
 
 #[async_std::main]
 async fn main() -> std::result::Result<(), std::io::Error> {
     pretty_env_logger::init();
+
+    let args = Args::from_args();
+
     let addr = format!(
-        "127.0.0.1:{}",
-        env::var("PORT").unwrap_or_else(|_| "4000".to_string())
+        "{}:{}",
+        args.host,
+        args.port
     );
 
     let state = State::new(
         Converter::new("https://api.github.com".to_string()),
-        FileFinder::new(PathBuf::from(".")),
+        FileFinder::new(args.folder),
     );
 
     let app = build_app(state);
 
     println!(
-        "Listening on {}\nYou can change the port with the PORT env var",
+        "Listening on {}",
         addr
     );
     app.listen(addr).await

--- a/static/LICENSE
+++ b/static/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2014-2019 Joe Esposito <joe@joeyespo.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
Add a CLI interface to make rs-readme easier to use.

Also add the license from `grip` to the css and font files I used from
that project.