### PR TITLE
Make checkboxes render

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,26 @@ rs-readme
 ```
 in any folder to start the server there.
 
+#### Options
+```
+USAGE:
+    rs-readme [OPTIONS]
+
+FLAGS:
+        --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -c, --context <context>    The GitHub context to render in, should be of the form: `user/repo` or `org/repo`
+    -f, --folder <folder>      The folder to use as the root when serving files [default: .]
+    -h, --host <host>          The host to serve the readme files on [default: 127.0.0.1]
+    -p, --port <port>          The port to serve the readme files on [default: 4000]
+```
+
 ### Todos (maybe)
 - [x] Add a real CLI
 - [ ] Better error messages
 - [ ] Auto reloading on file save
 - [ ] Testing on multiple platforms
 - [ ] Building for multiple platforms and hosting the binaries somewhere (probably github)
-- [ ] Figure out why checkboxes don't render
+- [x] Figure out why checkboxes don't render

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,10 @@ use std::path::PathBuf;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
-#[structopt(name = "rs-readme", about = "A simple web server for previewing .md files")]
+#[structopt(
+    name = "rs-readme",
+    about = "A simple web server for previewing .md files"
+)]
 pub struct Args {
     /// The host to serve the readme files on
     #[structopt(short, long, default_value = "127.0.0.1")]
@@ -15,4 +18,8 @@ pub struct Args {
     /// The folder to use as the root when serving files
     #[structopt(short, long, default_value = ".")]
     pub folder: PathBuf,
+
+    /// The GitHub context to render in, should be of the form: `user/repo` or `org/repo`
+    #[structopt(short, long)]
+    pub context: Option<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use structopt::StructOpt;
 
-use rs_readme::{build_app, State, Converter, FileFinder, Args};
+use rs_readme::{build_app, Args, Converter, FileFinder, State};
 
 #[async_std::main]
 async fn main() -> std::result::Result<(), std::io::Error> {
@@ -8,22 +8,15 @@ async fn main() -> std::result::Result<(), std::io::Error> {
 
     let args = Args::from_args();
 
-    let addr = format!(
-        "{}:{}",
-        args.host,
-        args.port
-    );
+    let addr = format!("{}:{}", args.host, args.port);
 
     let state = State::new(
-        Converter::new("https://api.github.com".to_string()),
+        Converter::new("https://api.github.com".to_string(), args.context),
         FileFinder::new(args.folder),
     );
 
     let app = build_app(state);
 
-    println!(
-        "Listening on {}",
-        addr
-    );
+    println!("Listening on {}", addr);
     app.listen(addr).await
 }


### PR DESCRIPTION
Turns out this is a GitHub Flavored Markdown thing, so I added an option
for users to provide a context, which will activate gfm mode when
rendering.

A user could actually enter any random string since GitHub doesn't
validate it at all.