### PR TITLE
Switches to tide 0.8.0 style errors

### DIFF
--- a/src/content_finder.rs
+++ b/src/content_finder.rs
@@ -15,7 +15,7 @@ use log::{error, warn};
 #[derive(Debug, PartialEq)]
 pub enum ContentError {
     /// The requested content couldn't be fetched (probably a file error)
-    CouldNotFetch,
+    CouldNotFetch(String),
 
     /// The requested content wasn't markdown
     NotMarkdown,
@@ -24,7 +24,9 @@ pub enum ContentError {
 impl fmt::Display for ContentError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ContentError::CouldNotFetch => write!(f, "Could not find the resource"),
+            ContentError::CouldNotFetch(resource) => {
+                write!(f, "Could not find {}", resource.replacen("./", "", 1))
+            }
             ContentError::NotMarkdown => write!(f, "The file was not markdown"),
         }
     }
@@ -74,7 +76,7 @@ impl ContentFinder for FileFinder {
                 path.to_string_lossy(),
                 err
             );
-            ContentError::CouldNotFetch
+            ContentError::CouldNotFetch(resource.to_string())
         })?;
 
         let mut contents = String::new();
@@ -84,7 +86,7 @@ impl ContentFinder for FileFinder {
                 path.to_string_lossy(),
                 err
             );
-            ContentError::CouldNotFetch
+            ContentError::CouldNotFetch(resource.to_string())
         })?;
 
         Ok(contents)


### PR DESCRIPTION
Since the handling of returning errors from endpoints doesn't let you
change HTTP headers it's not ergonomic to return HTML errors right now
as the `content-type` will always by `text/plain`. One of the endpoints
uses a match to return some HTML errors but the rest are just using the
built-in conversion right now.