### PR TITLE
Use HTML error messages

### DIFF
--- a/src/static_files.rs
+++ b/src/static_files.rs
@@ -1,8 +1,8 @@
 use super::{
     content_finder::ContentFinder, markdown_converter::MarkdownConverter, web_server::State,
 };
-use std::sync::Arc;
 use http_types::mime;
+use std::sync::Arc;
 use tide::{http::StatusCode, Request, Response};
 
 // This will bundle the necessary files in the final binary so we don't have to worry about
@@ -18,36 +18,32 @@ const STYLE_CSS: &str = include_str!("../static/style.css");
 
 /// The endpoint to return files related to octicons
 pub async fn octicons(
-    req: Request<Arc<State<impl MarkdownConverter + Send + Sync, impl ContentFinder + Send + Sync>>>,
+    req: Request<
+        Arc<State<impl MarkdownConverter + Send + Sync, impl ContentFinder + Send + Sync>>,
+    >,
 ) -> tide::Result {
     match req.param::<String>("file") {
         Ok(path) if path.starts_with("octicons.css") => Ok(Response::builder(StatusCode::Ok)
             .body(OCTICON_CSS.to_string())
             .content_type(mime::CSS)
             .build()),
-        Ok(path) if path.starts_with("octicons.eot") => {
-            Ok(Response::builder(StatusCode::Ok)
-                .body(OCTICON_EOT)
-                .content_type("application/vnd.ms-fontobject".parse().unwrap_or(mime::ANY))
-                .build())
-        }
-        Ok(path) if path.starts_with("octicons.svg") =>
-            Ok(Response::builder(StatusCode::Ok)
+        Ok(path) if path.starts_with("octicons.eot") => Ok(Response::builder(StatusCode::Ok)
+            .body(OCTICON_EOT)
+            .content_type("application/vnd.ms-fontobject".parse().unwrap_or(mime::ANY))
+            .build()),
+        Ok(path) if path.starts_with("octicons.svg") => Ok(Response::builder(StatusCode::Ok)
             .body(OCTICON_SVG.to_string())
             .content_type(mime::SVG)
             .build()),
-        Ok(path) if path.starts_with("octicons.ttf") =>
-            Ok(Response::builder(StatusCode::Ok)
+        Ok(path) if path.starts_with("octicons.ttf") => Ok(Response::builder(StatusCode::Ok)
             .body(OCTICON_TTF)
             .content_type("font/ttf".parse().unwrap_or(mime::ANY))
             .build()),
-        Ok(path) if path.starts_with("octicons.woff2") =>
-            Ok(Response::builder(StatusCode::Ok)
+        Ok(path) if path.starts_with("octicons.woff2") => Ok(Response::builder(StatusCode::Ok)
             .body(OCTICON_WOFF2)
             .content_type("font/woff2".parse().unwrap_or(mime::ANY))
             .build()),
-        Ok(path) if path.starts_with("octicons.woff") =>
-            Ok(Response::builder(StatusCode::Ok)
+        Ok(path) if path.starts_with("octicons.woff") => Ok(Response::builder(StatusCode::Ok)
             .body(OCTICON_WOFF)
             .content_type("font/woff".parse().unwrap_or(mime::ANY))
             .build()),
@@ -60,7 +56,9 @@ pub async fn octicons(
 
 /// The endpoint to return our styles
 pub async fn style(
-    _req: Request<Arc<State<impl MarkdownConverter + Send + Sync, impl ContentFinder + Send + Sync>>>,
+    _req: Request<
+        Arc<State<impl MarkdownConverter + Send + Sync, impl ContentFinder + Send + Sync>>,
+    >,
 ) -> tide::Result {
     Ok(Response::builder(StatusCode::Ok)
         .body(STYLE_CSS.to_string())

--- a/tests/route_tests.rs
+++ b/tests/route_tests.rs
@@ -7,7 +7,7 @@ use rs_readme::*;
 use rs_readme::{ContentError, ContentFinder, MarkdownConverter};
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
-use tide::http::{Method, Request, Url, Response};
+use tide::http::{Method, Request, Response, Url};
 
 /// A mock [`MarkdownConverter`] that returns:
 /// `<h1>A Readme</h1>`
@@ -256,11 +256,6 @@ async fn returns_400_for_non_md_file() {
 <!DOCTYPE html>\
 <html>\
   <head>\
-  <link rel=\"stylesheet\" href=\"/static/octicons/octicons.css\">\
-  <link rel=\"stylesheet\" href=\"https://github.githubassets.com/assets/frameworks-146fab5ea30e8afac08dd11013bb4ee0.css\">\
-  <link rel=\"stylesheet\" href=\"https://github.githubassets.com/assets/site-897ad5fdbe32a5cd67af5d1bdc68a292.css\">\
-  <link rel=\"stylesheet\" href=\"https://github.githubassets.com/assets/github-c21b6bf71617eeeb67a56b0d48b5bb5c.css\">\
-  <link rel=\"stylesheet\" href=\"/static/style.css\">\
     <title>rs-readme</title>\
   </head>\
   <body>\
@@ -300,7 +295,17 @@ async fn returns_404_for_missing_readme() {
     assert_eq!(mime, mime::HTML);
 
     let body = res.body_string().await.unwrap();
-    let expected_body = "Could not find README.md";
+    let expected_body = "\
+<!DOCTYPE html>\
+<html>\
+  <head>\
+    <title>rs-readme</title>\
+  </head>\
+  <body>\
+    <h1>Couldn't find README.md</h1>\
+    <p>For the index page <em>rs-readme</em> will look for a file named README in the root folder. Otherwise it looks for an exact file name.</p>\
+  </body>\
+</html>";
     assert_eq!(body, expected_body);
 }
 
@@ -333,7 +338,17 @@ async fn returns_404_for_missing_file() {
     assert_eq!(mime, mime::HTML);
 
     let body = res.body_string().await.unwrap();
-    let expected_body = "Could not find foo.md";
+    let expected_body = "\
+<!DOCTYPE html>\
+<html>\
+  <head>\
+    <title>rs-readme</title>\
+  </head>\
+  <body>\
+    <h1>Couldn't find ./foo.md</h1>\
+    <p>For the index page <em>rs-readme</em> will look for a file named README in the root folder. Otherwise it looks for an exact file name.</p>\
+  </body>\
+</html>";
     assert_eq!(body, expected_body);
 }
 
@@ -346,16 +361,11 @@ async fn static_content_returns_appropriate_files() {
     // Expected results
     // (path, status, mime, body)
     let expected = vec![
-        (
-            "/static/octicons/octicons.css",
-            200 as u16,
-            mime::CSS,
-            {
-                let mut vec = Vec::new();
-                vec.extend_from_slice(include_bytes!("../static/octicons/octicons.css"));
-                vec
-            },
-        ),
+        ("/static/octicons/octicons.css", 200 as u16, mime::CSS, {
+            let mut vec = Vec::new();
+            vec.extend_from_slice(include_bytes!("../static/octicons/octicons.css"));
+            vec
+        }),
         (
             "/static/octicons/octicons.eot",
             200,
@@ -371,21 +381,36 @@ async fn static_content_returns_appropriate_files() {
             vec.extend_from_slice(include_bytes!("../static/octicons/octicons.svg"));
             vec
         }),
-        ("/static/octicons/octicons.ttf", 200, "font/ttf".parse().unwrap(), {
-            let mut vec = Vec::new();
-            vec.extend_from_slice(include_bytes!("../static/octicons/octicons.ttf"));
-            vec
-        }),
-        ("/static/octicons/octicons.woff", 200, "font/woff".parse().unwrap(), {
-            let mut vec = Vec::new();
-            vec.extend_from_slice(include_bytes!("../static/octicons/octicons.woff"));
-            vec
-        }),
-        ("/static/octicons/octicons.woff2", 200, "font/woff2".parse().unwrap(), {
-            let mut vec = Vec::new();
-            vec.extend_from_slice(include_bytes!("../static/octicons/octicons.woff2"));
-            vec
-        }),
+        (
+            "/static/octicons/octicons.ttf",
+            200,
+            "font/ttf".parse().unwrap(),
+            {
+                let mut vec = Vec::new();
+                vec.extend_from_slice(include_bytes!("../static/octicons/octicons.ttf"));
+                vec
+            },
+        ),
+        (
+            "/static/octicons/octicons.woff",
+            200,
+            "font/woff".parse().unwrap(),
+            {
+                let mut vec = Vec::new();
+                vec.extend_from_slice(include_bytes!("../static/octicons/octicons.woff"));
+                vec
+            },
+        ),
+        (
+            "/static/octicons/octicons.woff2",
+            200,
+            "font/woff2".parse().unwrap(),
+            {
+                let mut vec = Vec::new();
+                vec.extend_from_slice(include_bytes!("../static/octicons/octicons.woff2"));
+                vec
+            },
+        ),
     ];
 
     for (path, status, mime, body) in expected.iter() {
@@ -400,9 +425,10 @@ async fn static_content_returns_appropriate_files() {
         let res_status = res.status();
         assert_eq!(&res_status, status, "path: {}", path);
 
-        let res_mime = res
-            .content_type()
-            .expect(&format!("Couldn't get the content-type header, path: {}", path));
+        let res_mime = res.content_type().expect(&format!(
+            "Couldn't get the content-type header, path: {}",
+            path
+        ));
         assert_eq!(res_mime, *mime, "path: {}", path);
 
         let mut res_body = Vec::with_capacity(1);


### PR DESCRIPTION
Rewrote the error messages to be nice HTML and wrote an error-handling
middleware to format messages and extract error formatting from the
handler logic.