### PR TITLE
Add auto-refresh with SSE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1542,6 +1542,7 @@ dependencies = [
  "async-std",
  "async-trait",
  "futures 0.3.5",
+ "generic-array",
  "horrorshow",
  "http-service",
  "http-service-mock",
@@ -1553,6 +1554,8 @@ dependencies = [
  "pulldown-cmark",
  "serde",
  "serde_derive",
+ "serde_json",
+ "sha-1",
  "structopt",
  "surf",
  "tide",
@@ -1669,6 +1672,19 @@ dependencies = [
  "itoa",
  "serde",
  "url",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170a36ea86c864a3f16dd2687712dd6646f7019f301e57537c7f4dc9f5916770"
+dependencies = [
+ "block-buffer",
+ "cfg-if",
+ "cpuid-bool",
+ "digest",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,10 @@ horrorshow = "0.8.3"
 http-types = "2.3.0"
 structopt = "0.3.12"
 pulldown-cmark = { version = "0.7.2", default-features = false }
+sha-1 = "0.9.1"
+generic-array = "0.14.3"
+serde_json = "1.0.57"
+
 
 [dev-dependencies]
 mockito = "0.23.3"

--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ USAGE:
 
 FLAGS:
         --help       Prints help information
-    -o, --offline    Whether to run in offline mode, using a built in markdown converter. May not be 100% accurate to
-                     GitHub
     -V, --version    Prints version information
 
 OPTIONS:
@@ -50,8 +48,9 @@ OPTIONS:
 ### Todos (maybe)
 - [x] Add a real CLI
 - [ ] Better error messages
-- [ ] Auto reloading on file save
+- [x] Auto reloading on file save
 - [ ] Testing on multiple platforms
 - [ ] Building for multiple platforms and hosting the binaries somewhere (probably github)
 - [x] Figure out why checkboxes don't render
 - [x] Offline rendering
+- [ ] Add image serving to support embedded images

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,9 +22,9 @@ pub struct Args {
     /// The GitHub context to render in, should be of the form: `user/repo` or `org/repo`
     #[structopt(short, long)]
     pub context: Option<String>,
-
-    /// Whether to run in offline mode, using a built in markdown converter. May
-    /// not be 100% accurate to GitHub
-    #[structopt(short, long)]
-    pub offline: bool,
+    // Whether to run in online mode, making calls to GitHub. Should only be
+    // used if the offline renderer is not
+    // Disabled until I can do server sent events without calling GitHub every time
+    // #[structopt(short, long)]
+    // pub online: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use structopt::StructOpt;
 
-use rs_readme::{build_app, Args, Converter, Converters, FileFinder, OfflineConverter, State};
+use rs_readme::{build_app, Args, Converters, FileFinder, OfflineConverter, State};
 
 #[async_std::main]
 async fn main() -> std::result::Result<(), std::io::Error> {
@@ -11,14 +11,15 @@ async fn main() -> std::result::Result<(), std::io::Error> {
 
     let addr = format!("{}:{}", args.host, args.port);
 
-    let converter = if args.offline {
-        Converters::Offline(OfflineConverter::new())
-    } else {
-        Converters::Github(Converter::new(
-            "https://api.github.com".to_string(),
-            args.context,
-        ))
-    };
+    let converter = Converters::Offline(OfflineConverter::default());
+    // let converter = if args.offline {
+    //     Converters::Offline(OfflineConverter::new())
+    // } else {
+    //     Converters::Github(Converter::new(
+    //         "https://api.github.com".to_string(),
+    //         args.context,
+    //     ))
+    // };
 
     let state = State::new(converter, FileFinder::new(args.folder));
 


### PR DESCRIPTION
Add auto-refresh with SSE. It's going to be a significant undertaking to
maintain the state of the file on the server. Right now the server
always sends the file hash and the file contents with every event. The
front end will check if the hash is different and update the content if
the hash changed.

I also set it to always render in offline mode since the SSE would be
calling the GitHub API every few seconds and get rate limited.